### PR TITLE
This makes it possible to build and run the ringG test again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,11 @@ set(DCA_LIBS
   cuda_utils
 )
 
+set(SYSTEM_GPU_COUNT 0)
+
 if (DCA_HAVE_CUDA)
+  EXECUTE_PROCESS(COMMAND bash -c "nvidia-smi -L | awk 'BEGIN { num_gpu=0;} /GPU/ { num_gpu++;} END { printf(\"%d\", num_gpu) }'"
+                  OUTPUT_VARIABLE SYSTEM_GPU_COUNT)
   list(APPEND DCA_LIBS
     blas_kernels
     dnfft_kernels
@@ -166,6 +170,8 @@ option(DCA_WITH_TESTS_FAST "Build DCA++'s fast tests." OFF)
 option(DCA_WITH_TESTS_EXTENSIVE "Build DCA++'s extensive tests." OFF)
 option(DCA_WITH_TESTS_PERFORMANCE "Build DCA++'s performance tests. (Only in Release mode.)" OFF)
 option(DCA_WITH_TESTS_STOCHASTIC  "Build DCA++'s stochastic tests." OFF)
+
+set(DCA_TEST_GPU_COUNT "${SYSTEM_GPU_COUNT}" CACHE INTEGER "Number of GPUs available on one node for one test.")
 
 set(TEST_RUNNER "" CACHE STRING "Command for executing (MPI) programs.")
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "Flag used by TEST_RUNNER to specify the number of processes.")

--- a/cmake/dca_cuda.cmake
+++ b/cmake/dca_cuda.cmake
@@ -21,9 +21,7 @@ if (CUDA_FOUND)
   CUDA_INCLUDE_DIRECTORIES(${CUDA_INCLUDE_DIRS})
   set(CUDA_SEPARABLE_COMPILATION ON)
 
-  set(CVD_LAUNCHER "" CACHE INTERNAL "launch script for setting the Cuda visible devices.")
-  # Use the following script for systems with multiple gpus visible from a rank.
-  # set(CVD_LAUNCHER "test/cvd_launcher.sh" CACHE INTERNAL "")
+  set(CVD_LAUNCHER "test/cvdlauncher.sh" CACHE INTERNAL "launch script for setting the Cuda visible devices.")
 endif()
 
 # Find MAGMA.

--- a/cmake/dca_testing.cmake
+++ b/cmake/dca_testing.cmake
@@ -13,7 +13,7 @@ include(CMakeParseArguments)
 #               [FAST | EXTENSIVE | STOCHASTIC | PERFORMANCE]
 #               [GTEST_MAIN]
 #               [MPI [MPI_NUMPROC procs]]
-#               [CUDA]
+#               [CUDA | CUDA_MPI]
 #               [INCLUDE_DIRS dir1 [dir2 ...]]
 #               [SOURCES src1 [src2 ...]]
 #               [LIBS lib1 [lib2 ...]])
@@ -41,7 +41,7 @@ function(dca_add_gtest name)
                                        [FAST | EXTENSIVE | STOCHASTIC | PERFORMANCE]\n
                                        [GTEST_MAIN]\n
                                        [MPI [MPI_NUMPROC procs]]\n
-                                       [CUDA]\n
+                                       [CUDA | CUDA_MPI]\n
                                        [INCLUDE_DIRS dir1 [dir2 ...]]\n
                                        [SOURCES src1 [src2 ...]]\n
                                        [LIBS lib1 [lib2 ...]])")
@@ -82,13 +82,9 @@ function(dca_add_gtest name)
     return()
   endif()
 
-  if (DCA_ADD_GTEST_CUDA_MPI AND (NOT (DCA_HAVE_CUDA AND DCA_HAVE_CUDA_AWARE_MPI)))
-    return()
-  endif()
-
   # Right now we're only testing GPU distributed code on one node so its pointless
   # without more than one GPU per node.
-  if (DCA_ADD_GTEST_CUDA_MPI AND (DCA_TEST_GPU_COUNT LESS 2) )
+  if (DCA_ADD_GTEST_CUDA_MPI AND DCA_HAVE_CUDA_AWARE_MPI AND (DCA_TEST_GPU_COUNT LESS 2) )
     return()
   endif()
 

--- a/test/integration/cluster_solver/shared_tools/accumulation/tp/CMakeLists.txt
+++ b/test/integration/cluster_solver/shared_tools/accumulation/tp/CMakeLists.txt
@@ -1,7 +1,7 @@
 dca_add_gtest(ringG_tp_accumulator_gpu_test
-        CUDA_MPI
-        MPI MPI_NUMPROC ${DCA_TEST_GPU_COUNT}
-        GTEST_MAIN
-        INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}
-        LIBS     ${DCA_LIBS} parallel_mpi_concurrency
-        )
+ FAST
+ CUDA_MPI
+ MPI MPI_NUMPROC ${DCA_TEST_GPU_COUNT}
+ GTEST_MAIN
+ INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}
+ LIBS     ${DCA_LIBS} parallel_mpi_concurrency)

--- a/test/integration/cluster_solver/shared_tools/accumulation/tp/CMakeLists.txt
+++ b/test/integration/cluster_solver/shared_tools/accumulation/tp/CMakeLists.txt
@@ -1,8 +1,7 @@
 dca_add_gtest(ringG_tp_accumulator_gpu_test
-        EXTENSIVE
+        CUDA_MPI
+        MPI MPI_NUMPROC ${DCA_TEST_GPU_COUNT}
         GTEST_MAIN
-        CUDA
-        MPI MPI_NUMPROC 3
         INCLUDE_DIRS ${DCA_INCLUDE_DIRS};${PROJECT_SOURCE_DIR}
         LIBS     ${DCA_LIBS} parallel_mpi_concurrency
         )

--- a/test/integration/cluster_solver/shared_tools/accumulation/tp/ringG_tp_accumulator_gpu_test.cpp
+++ b/test/integration/cluster_solver/shared_tools/accumulation/tp/ringG_tp_accumulator_gpu_test.cpp
@@ -26,8 +26,7 @@
 
 constexpr bool update_baseline = false;
 
-#define INPUT_DIR \
-  DCA_SOURCE_DIR "/test/integration/cluster_solver/shared_tools/accumulation/tp/"
+#define INPUT_DIR DCA_SOURCE_DIR "/test/integration/cluster_solver/shared_tools/accumulation/tp/"
 
 constexpr char input_file[] = INPUT_DIR "input_4x4_multitransfer.json";
 
@@ -41,48 +40,53 @@ using DistributedTpAccumulatorGpuTest =
 uint loop_counter = 0;
 
 TEST_F(DistributedTpAccumulatorGpuTest, Accumulate) {
-    dca::linalg::util::initializeMagma();
+  dca::linalg::util::initializeMagma();
 
-    const std::array<int, 2> n{27, 24};
-    Sample M;
-    Configuration config;
-    ConfigGenerator::prepareConfiguration(config, M, DistributedTpAccumulatorGpuTest::BDmn::dmn_size(),
-          DistributedTpAccumulatorGpuTest::RDmn::dmn_size(),
+  const std::array<int, 2> n{27, 24};
+  Sample M;
+  Configuration config;
+  ConfigGenerator::prepareConfiguration(config, M, DistributedTpAccumulatorGpuTest::BDmn::dmn_size(),
+                                        DistributedTpAccumulatorGpuTest::RDmn::dmn_size(),
                                         parameters_.get_beta(), n);
 
-    using namespace dca::phys;
-    parameters_.set_four_point_channels(
+  using namespace dca::phys;
+  parameters_.set_four_point_channels(
       std::vector<FourPointType>{PARTICLE_HOLE_TRANSVERSE, PARTICLE_HOLE_MAGNETIC,
                                  PARTICLE_HOLE_CHARGE, PARTICLE_HOLE_LONGITUDINAL_UP_UP,
                                  PARTICLE_HOLE_LONGITUDINAL_UP_DOWN, PARTICLE_PARTICLE_UP_DOWN});
 
-    dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::CPU> accumulatorHost(
-            data_->G0_k_w_cluster_excluded, parameters_);
-    dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::GPU, dca::DistType::MPI> accumulatorDevice(
+  dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::CPU> accumulatorHost(
       data_->G0_k_w_cluster_excluded, parameters_);
-    const int sign = 1;
+  dca::phys::solver::accumulator::TpAccumulator<Parameters, dca::linalg::GPU, dca::DistType::MPI>
+      accumulatorDevice(data_->G0_k_w_cluster_excluded, parameters_);
+  const int sign = 1;
 
-    accumulatorDevice.resetAccumulation(loop_counter);
-    accumulatorDevice.accumulate(M, config, sign);
-    accumulatorDevice.finalize();
+  accumulatorDevice.resetAccumulation(loop_counter);
+  accumulatorDevice.accumulate(M, config, sign);
+  accumulatorDevice.finalize();
 
-    accumulatorHost.resetAccumulation(loop_counter);
-    accumulatorHost.accumulate(M, config, sign);
-    accumulatorHost.finalize();
+  accumulatorHost.resetAccumulation(loop_counter);
+  accumulatorHost.accumulate(M, config, sign);
+  accumulatorHost.finalize();
 
-    ++loop_counter;
+  ++loop_counter;
 
-    auto& concurrency = parameters_.get_concurrency();
-    for (int channel = 0; channel < accumulatorDevice.get_sign_times_G4().size(); ++channel) {
-        auto G4_gpu = accumulatorDevice.get_sign_times_G4()[channel];
-        auto G4_cpu = accumulatorHost.get_sign_times_G4()[channel];
-        auto G4_gathered = G4_gpu.gather(concurrency);
-        concurrency_.localSum(G4_cpu, concurrency.first());
-        if (concurrency.get_id() == 0 && channel == 0){
-            const auto diff = dca::func::util::difference(G4_cpu, G4_gathered);
-            EXPECT_GT(5e-7, diff.l_inf);
-            EXPECT_GT(5e-7, diff.l1);
-            EXPECT_GT(5e-7, diff.l2);
-        }
+  auto& concurrency = parameters_.get_concurrency();
+
+  if (concurrency.get_id())
+    std::cout << "\nCollecting Data from G4 distributed over" << concurrency.number_of_processors()
+              << "ranks\n";
+
+  for (int channel = 0; channel < accumulatorDevice.get_sign_times_G4().size(); ++channel) {
+    auto G4_gpu = accumulatorDevice.get_sign_times_G4()[channel];
+    auto G4_cpu = accumulatorHost.get_sign_times_G4()[channel];
+    auto G4_gathered = G4_gpu.gather(concurrency);
+    concurrency_.localSum(G4_cpu, concurrency.first());
+    if (concurrency.get_id() == 0 && channel == 0) {
+      const auto diff = dca::func::util::difference(G4_cpu, G4_gathered);
+      EXPECT_GT(5e-7, diff.l_inf);
+      EXPECT_GT(5e-7, diff.l1);
+      EXPECT_GT(5e-7, diff.l2);
     }
+  }
 }


### PR DESCRIPTION
It now uses whatever is the maximum number of GPU's on the node (actually the build node) and also requires the cmake variable `DCA_HAVE_CUDA_AWARE_MPI=1`

If you have a situation where the number of GPU on the build node is different from the compute node where the test will be run you need to manually set
`DCA_TEST_GPU_COUNT=<NUMBER OF GPUS ON NODE>`

Right now a wrapper script is part of these test invocations, all it does is set the CUDA_VISIBLE_DEVICES to have only one GPU visible per rank.  This doesn't interfere with the required `-smpiargs=gpu` on summit.  

I'm still looking into which mpi implementations require this and which don't.  Spectrum and the newest openmpi with CUDA don't actually require CUDA_VISIBLE_DEVICES to be set, so the wrapped may be dropped soon.